### PR TITLE
Fixed Swift Compiler Error

### DIFF
--- a/Bot Shop/Controllers/OrderList.swift
+++ b/Bot Shop/Controllers/OrderList.swift
@@ -51,14 +51,14 @@ class OrderList: UIViewController {
 extension OrderList: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         
-        return currentOrder.items.count
+        return orders.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath) as! PastOrderCell
             cell.accessoryType = .disclosureIndicator
             cell.selectionStyle = .none
-            cell.setCellContents(item: currentOrder.items[indexPath.row])
+            cell.setCellContents(item: orderItems[indexPath.row])
         
         return cell
     }


### PR DESCRIPTION
Addressed: Value of type 'Order' has no member 'items'

Explanation: Order only has values title and image so your code broke when you tried to access items in Order because it doesn't exist in Order. Instead, access orderItems which is an array of type Items ([Item])